### PR TITLE
fix bug with `rake check` not properly outputting missing environment va...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :check do
   errors = []
   environemnt_vars.each do |var|
     if ENV[var].nil?
-      errors.push(" - \e\[31m#Variable: {var} not set!\e\[0m\n")
+      errors.push(" - \e\[31m#Variable: #{var} not set! Look at the environment.sh file\e\[0m\n")
     else
       puts " - \e\[32mVariable: #{var} set to \"#{ENV[var]}\"\e\[0m\n"
     end


### PR DESCRIPTION
It seems `rake check` only outputs 

The following errors occured:
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!
- #Variable: {var} not set!

When you do not have any of the environment.sh variables set.

This fixes the issue and tells users about the environment.sh

This is my first time pull request, so please tell me if its easier if I do this in a different way.

![screen shot 2013-06-13 at - jun 13 1 03 47 pm](https://f.cloud.github.com/assets/619902/650066/b7c327e2-d453-11e2-94fb-f41c4826f165.png)
